### PR TITLE
fix(acme): reload murmur on cert renewal

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,18 +1,18 @@
 ---
 
-version: '3'
-
 services:
   lego:
     build:
       context: ./lego/
       args:
-        ALPINE_VERSION: '3.18'
-        GOLANG_VERSION: '1.21'
-        LEGO_VERSION: v4.14.0
+        ALPINE_VERSION: '3.20'
+        GOLANG_VERSION: '1.22'
+        LEGO_VERSION: 'v4.19.2'
     environment:
       DOMAINS: ${DOMAINS}
       EMAIL: ${EMAIL}
+      RELOAD_PROCESSES_SIGHUP: ${RELOAD_PROCESSES_SIGHUP}
+      RELOAD_PROCESSES_SIGUSR1: ${RELOAD_PROCESSES_SIGUSR1}
     volumes:
       - letsencrypt:/letsencrypt
     ports:
@@ -23,8 +23,8 @@ services:
     build:
       context: ./murmur/
       args:
-        ALPINE_VERSION: '3.18'
-        MURMUR_VERSION: '1.4.287-r4'
+        ALPINE_VERSION: '3.20'
+        MURMUR_VERSION: '1.4.287-r11'
     volumes:
       - db:/data
       - logs:/logs
@@ -33,6 +33,9 @@ services:
     ports:
       - 64738:64738/tcp
       - 64738:64738/udp
+    # Share the PID namespace of lego container
+    # This allows lego to see the Murmur service and restart it
+    pid: service:lego
 
 volumes:
   db:

--- a/lego/run_lego.sh
+++ b/lego/run_lego.sh
@@ -29,9 +29,21 @@ if [ -z "${EMAIL}" ]; then
 	exit 3
 fi
 
+DOMAIN_ARG=''
+for DOMAIN in ${DOMAINS}; do
+    DOMAIN_ARG="${DOMAIN_ARG} --domains=${DOMAIN}"
+done
+
 lego --accept-tos --path="${LE_PATH}" --server="${URL}" --email="${EMAIL}" \
 	--key-type="${KEY_TYPE}" \
-	--domains="${DOMAINS}" \
+    ${DOMAIN_ARG} \
 	--pem \
 	--tls \
 	"${MODE}"
+
+for PROCESS in ${RELOAD_PROCESSES_SIGHUP}; do
+	pkill -HUP "${PROCESS}"
+done
+for PROCESS in ${RELOAD_PROCESSES_SIGUSR1}; do
+	pkill -USR1 "${PROCESS}"
+done

--- a/murmur.conf
+++ b/murmur.conf
@@ -1,26 +1,44 @@
-port=64738
 host=0.0.0.0
+port=64738
+
+serverpassword=
+
+timeout=5
+bandwidth=130000
 
 sslCert=/letsencrypt/certificates/mumble.awicks.io.pem
 sslKey=/letsencrypt/certificates/mumble.awicks.io.key
 
-serverpassword=
+bonjour=false
 
-welcometext="<br />Welcome to <b>Alex's Mumble server</b><br />"
 
 database=/data/murmur.sqlite
 
 logfile=/logs/murmur.log
 logdays=-1
 
-users=20
-bandwidth=130000
+
+sendversion=true
+
+defaultchannel=2
+rememberchannel=false
 
 
-messageburst=999
-messagelimit=999
+welcometext="<br />Welcome to <strong>Alex's Mumble server</strong><br />"
 
-sendversion=True
+users=100
+suggestPushToTalk=true
+certrequired=true
+
+listenersperchannel=0
+listenersperuser=0
+
+
+messageburst=9999
+messagelimit=9999
+imagemessagelength=131072
+autobanAttempts = 0
+autobanTimeframe = 0
 
 [Ice]
 Ice.Warn.UnknownProperties=1


### PR DESCRIPTION
Previously, Murmur would keep using the certificate loaded at startup even when `lego` had rotated it. This PR:

- Makes the `murmur` container share the PID namespace of the `lego` container
- Allows sending a `SIGHUP` or `SIGUSR1` to processes after `lego` issues/renews certificates

Additional misc changes/fixes:
- Bump Alpine image to `3.20`
- Bump `lego` from `v4.14.0` to `v4.19.2`
- Handle multiple domains in `lego` command correctly
- Tidy up `murmur.conf`